### PR TITLE
More stopping criterion

### DIFF
--- a/src/slsqp_core.f90
+++ b/src/slsqp_core.f90
@@ -1413,7 +1413,7 @@
     ! if all new constrained coeffs are feasible then alpha will
     ! still = 2.    if so exit from secondary loop to main loop.
 
-    if ( alpha==two ) then
+    if ( abs(alpha-two)<=0. ) then
         ! ******  end of secondary loop  ******
 
         do ip = 1 , nsetp
@@ -1773,7 +1773,7 @@
                     sm = sm + c(i3)*u(1,i)
                     i3 = i3 + ice
                 end do
-                if ( sm/=0 ) then
+                if ( abs(sm)>0 ) then
                     sm = sm*b
                     c(i2) = c(i2) + sm*up
                     do i = l1 , m
@@ -1831,7 +1831,7 @@
         s = c*xr
         sig = abs(a)*yr
     else
-        if ( b/=zero ) then
+        if ( abs(b)>zero ) then
             xr = a/b
             yr = sqrt(one+xr**2)
             s = sign(one/yr,b)
@@ -1883,7 +1883,7 @@
     integer :: i , ij , j
     real(wp) :: t , v , u , tp , beta , alpha , delta , gamma
 
-    if ( sigma/=zero ) then
+    if ( abs(sigma)>zero ) then
         ij = 1
         t = one/sigma
         if ( sigma<=zero ) then
@@ -2004,12 +2004,12 @@
         if ( fu>fx ) then
             if ( u<x ) a = u
             if ( u>=x ) b = u
-            if ( fu<=fw .or. w==x ) then
+            if ( fu<=fw .or. abs(w-x)<=0._wp ) then
                 v = w
                 fv = fw
                 w = u
                 fw = fu
-            else if ( fu<=fv .or. v==x .or. v==w ) then
+            else if ( fu<=fv .or. abs(v-x)<=0._wp .or. abs(v-w)<=0._wp ) then
                 v = u
                 fv = fu
             end if

--- a/src/slsqp_module.f90
+++ b/src/slsqp_module.f90
@@ -27,7 +27,10 @@
         integer  :: m           = 0        !! number of constraints (\( m \ge 0 \))
         integer  :: meq         = 0        !! number of equality constraints (\( m \ge m_{eq} \ge 0 \))
         integer  :: max_iter    = 0        !! maximum number of iterations
-        real(wp) :: acc         = zero     !! accuracy tolerance
+        real(wp) :: acc         = zero      !! accuracy tolerance
+        real(wp) :: tolf        = zero     !! accuracy tolerance over f:  if |f| < tolf then stop
+        real(wp) :: toldf       = zero     !! accuracy tolerance over df: if |fn+1 - fn| < toldf then stop
+        real(wp) :: toldx       = zero     !! accuracy tolerance over xf: if |xn+1 - xn| < toldx then stop
 
         integer  :: gradient_mode = 0      !! how the gradients are computed:
                                            !!

--- a/src/slsqp_support.f90
+++ b/src/slsqp_support.f90
@@ -42,7 +42,7 @@
     integer :: i , incx , incy , ix , iy , m , mp1 , n
 
     if ( n<=0 ) return
-    if ( da==zero ) return
+    if ( abs(da)<=zero ) return
     if ( incx==1 .and. incy==1 ) then
 
         ! code for both increments equal to 1
@@ -243,7 +243,7 @@
         ! auxiliary routine:
         ! call dlassq( n, x, incx, scale, ssq )
         do ix = 1 , 1 + (n-1)*incx , incx
-            if ( x(ix)/=zero ) then
+            if ( abs(x(ix))>zero ) then
                 absxi = abs(x(ix))
                 if ( scale<absxi ) then
                     ssq = one + ssq*(scale/absxi)**2

--- a/src/tests/slsqp_test_stopping_criterion.f90
+++ b/src/tests/slsqp_test_stopping_criterion.f90
@@ -1,0 +1,132 @@
+!*******************************************************************************
+!> author: Pierre Payen
+!
+!  Test for the [[slsqp_module]].
+
+    module report_variable
+        
+        use slsqp_kinds
+        
+        implicit none
+        
+        real(wp) :: flast
+        real(wp),dimension(2) :: xlast
+        real(wp),dimension(1) :: clast
+    
+    end module
+
+    program slsqp_test_criterion
+
+    use slsqp_module
+    use slsqp_kinds
+    use report_variable
+
+    implicit none
+
+    integer,parameter               :: n = 2                    !! number of optimization variables
+    integer,parameter               :: m = 1                    !! total number of constraints
+    integer,parameter               :: meq = 0                  !! number of equality constraints
+    integer,parameter               :: max_iter = 100           !! maximum number of allowed iterations
+    real(wp),dimension(n),parameter :: xl = [-1.0_wp, -1.0_wp]  !! lower bounds
+    real(wp),dimension(n),parameter :: xu = [ 1.0_wp,  1.0_wp]  !! upper bounds
+    real(wp),parameter              :: acc  = 1.0e-8_wp         !! accuracy tolerance
+    real(wp),parameter              :: tolf  = 1.0e-8_wp        !! accuracy tolerance over f:  if |f| < tolf then stop
+    real(wp),parameter              :: toldf = 1.0e-8_wp        !! accuracy tolerance over df: if |fn+1 - fn| < toldf then stop
+    real(wp),parameter              :: toldx = 1.0e-8_wp        !! accuracy tolerance over dx: if |xn+1 - xn| < toldx then stop
+    integer,parameter               :: linesearch_mode = 1      !! use inexact linesearch.
+
+    type(slsqp_solver)    :: solver      !! instantiate an slsqp solver
+    real(wp),dimension(n) :: x           !! optimization variable vector
+    integer               :: istat       !! for solver status check
+    logical               :: status_ok   !! for initialization status check
+    integer               :: iterations  !! number of iterations by the solver
+
+    x = [0.1_wp, 0.1_wp] !initial guess
+    xlast = x
+    call rosenbrock_func(solver,xlast,flast,clast)
+
+    call solver%initialize(n,m,meq,max_iter,acc,rosenbrock_func,rosenbrock_grad,&
+                            xl,xu,linesearch_mode=linesearch_mode,status_ok=status_ok,&
+                            report=report_iteration)
+                            !alphamin=0.1_wp, alphamax=0.5_wp) !to limit search steps
+
+    if (status_ok) then
+        call solver%optimize(x,istat,iterations)
+        write(*,*) ''
+        write(*,*) 'solution   :', x
+        write(*,*) 'istat      :', istat
+        write(*,*) 'iterations :', iterations
+        write(*,*) ''
+    else
+        error stop 'error calling slsqp.'
+    end if
+
+    !solution:  x1 = 0.78641515097183889
+    !           x2 = 0.61769831659541152
+    !           f  = 4.5674808719160388E-002
+    !           c  = 2.8654301154062978E-012
+
+    contains
+
+    subroutine rosenbrock_func(me,x,f,c)
+        !! Rosenbrock function
+        !!
+        !! Minimize the Rosenbrock function: \( f(x) = 100 (x_2 - x_1)^2 + (1 - x_1)^2 \),
+        !! subject to the inequality constraint: \( x_1^2 + x_2^2 \le 1 \).
+        !!
+        !! see: http://www.mathworks.com/help/optim/ug/example-nonlinear-constrained-minimization.html
+        implicit none
+        class(slsqp_solver),intent(inout) :: me
+        real(wp),dimension(:),intent(in)  :: x      !! optimization variable vector
+        real(wp),intent(out)              :: f      !! value of the objective function
+        real(wp),dimension(:),intent(out) :: c      !! the constraint vector `dimension(m)`,
+                                                    !! equality constraints (if any) first.
+
+        f = 100.0_wp*(x(2) - x(1)**2)**2 + (1.0_wp - x(1))**2  !objective function
+        c(1) = 1.0_wp - x(1)**2 - x(2)**2  !equality constraint (>=0)
+
+    end subroutine rosenbrock_func
+
+    subroutine rosenbrock_grad(me,x,g,a)
+        !! gradients for [[rosenbrock_func]].
+        implicit none
+        class(slsqp_solver),intent(inout)   :: me
+        real(wp),dimension(:),intent(in)    :: x    !! optimization variable vector
+        real(wp),dimension(:),intent(out)   :: g    !! objective function partials w.r.t x `dimension(n)`
+        real(wp),dimension(:,:),intent(out) :: a    !! gradient matrix of constraints w.r.t. x `dimension(m,n)`
+
+        g(1) = -400.0_wp*(x(2)-x(1)**2)*x(1) - 2.0_wp*(1.0_wp-x(1))  !df/x1
+        g(2) = 200.0_wp*(x(2) - x(1)**2)                             !df/x2
+
+        a(1,1) = -2.0_wp*x(1)     ! dc/dx1
+        a(1,2) = -2.0_wp*x(2)     ! dc/dx2
+
+    end subroutine rosenbrock_grad
+
+    subroutine report_iteration(me,iter,x,f,c)
+        use, intrinsic :: iso_fortran_env, only: output_unit
+        use report_variable
+        !! report an iteration (print to the console).
+        implicit none
+        class(slsqp_solver),intent(inout) :: me
+        integer,intent(in)                :: iter
+        real(wp),dimension(:),intent(in)  :: x
+        real(wp),intent(in)               :: f
+        real(wp),dimension(:),intent(in)  :: c
+
+        !write a header:
+        if (iter==0) then
+            write(output_unit,'(*(A20,1X))') 'iteration', 'f','|df|','x(1)', 'x(2)', '|dx|', 'c(1)'
+        end if
+
+        !write the iteration data:
+        write(output_unit,'(I20,1X,(*(F20.16,1X)))') iter,f,abs(f-flast),x,sqrt(sum((x-xlast)**2)),c
+
+        xlast = x
+        flast = f
+        clast = c
+
+    end subroutine report_iteration
+
+    end program
+!*******************************************************************************


### PR DESCRIPTION
I've added 3 stopping criterion:
- `tolf`, a stopping criterion on the cost function: if `f < tolf` then stop
- `toldf`, a criterion on the variation of the cost function: if `|fn - fn-1| < toldf` then stop. This is almost the same criterion as `acc`.
- `toldx`, a criterion on the norm of the variation of the unknow vector: if ||`xn -xn-1|| < toldx`

I added them to be able to reproduce the matlab implementation of SLSQP.
